### PR TITLE
Remove back button from home for mobile

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,8 +62,11 @@ class Statera extends StatelessWidget {
                 theme: theme,
                 darkTheme: darkTheme,
                 themeMode: ThemeMode.system,
+                initialRoute: kIsWeb
+                    ? LandingPage.route
+                    // see https://api.flutter.dev/flutter/material/MaterialApp/initialRoute.html for explanation
+                    : GroupList.route.replaceFirst('/', ''),
                 onGenerateRoute: onGenerateRoute,
-                initialRoute: kIsWeb ? LandingPage.route : GroupList.route,
                 debugShowCheckedModeBanner: false,
               ),
             );

--- a/lib/ui/routing/pages.dart
+++ b/lib/ui/routing/pages.dart
@@ -7,7 +7,6 @@ import 'package:statera/business_logic/expense/expense_bloc.dart';
 import 'package:statera/business_logic/expenses/expenses_cubit.dart';
 import 'package:statera/business_logic/group/group_cubit.dart';
 import 'package:statera/business_logic/groups/groups_cubit.dart';
-import 'package:statera/business_logic/notifications/notifications_cubit.dart';
 import 'package:statera/business_logic/owing/owing_cubit.dart';
 import 'package:statera/data/services/services.dart';
 import 'package:statera/dynamic_link_handler.dart';


### PR DESCRIPTION
Apparently if the `initialRoute` starts with a `/`, for example `/foo/bar`, preceding routes would be pushed: `/`, `/foo` and `/foo/bar`. So having `initialRoute` as `/groups` for mobile was actually pushing `/` first (the landing page), and only then navigating to the groups list, hence the back button.

Closes #104 