### PR TITLE
Fix FAB group overflow

### DIFF
--- a/lib/business_logic/expense/expense_bloc.dart
+++ b/lib/business_logic/expense/expense_bloc.dart
@@ -44,7 +44,7 @@ class ExpenseBloc extends Bloc<ExpenseEvent, ExpenseState> {
     await event.update(expense);
 
     updateTimer?.cancel();
-    updateTimer = Timer(Duration(seconds: 3), () async {
+    updateTimer = Timer(Duration(seconds: 2), () async {
       await _expenseService.updateExpense(expense);
 
       // TODO: move to cloud functions (firestore trigger)

--- a/lib/ui/groups/group_list_body.dart
+++ b/lib/ui/groups/group_list_body.dart
@@ -61,9 +61,12 @@ class GroupListBody extends StatelessWidget {
                       : GridView.count(
                           crossAxisCount: columnCount,
                           childAspectRatio: columnWidth / 100,
-                          children: groups
-                              .map((group) => GroupListItem(group: group))
-                              .toList(),
+                          children: [
+                            ...groups
+                                .map((group) => GroupListItem(group: group))
+                                .toList(),
+                            SizedBox(height: 100) // leave space for FAB
+                          ],
                         ),
                 ),
               ],


### PR DESCRIPTION
# Description

- Adds extra space at the end of the group list so that the FAB does not overflow
- Decreases expense updating delay to 2 seconds

# Issue

This PR closes #258 

# Checklist

- [ ] This PR adds new tests
- [ ] This PR adds environment variables/files
- [ ] This PR updates documentation as required
