### PR TITLE
Improve back button behaviour

### DIFF
--- a/lib/ui/expense/expense_page.dart
+++ b/lib/ui/expense/expense_page.dart
@@ -70,7 +70,7 @@ class ExpensePage extends StatelessWidget {
             canPop: allItemsMarked,
             onPop: (didPop) async {
               if (didPop) return;
-              final confirmed = await showDialog(
+              final confirmed = await showDialog<bool>(
                 context: context,
                 builder: (_) => OKCancelDialog(
                   title: 'Are you sure you want to exit?',

--- a/lib/ui/expense/expense_page.dart
+++ b/lib/ui/expense/expense_page.dart
@@ -9,6 +9,7 @@ import 'package:statera/ui/expense/actions/expense_actions_button.dart';
 import 'package:statera/ui/expense/expense_details.dart';
 import 'package:statera/ui/expense/expense_details_loading.dart';
 import 'package:statera/ui/expense/items/item_action.dart';
+import 'package:statera/ui/widgets/dialogs/dialogs.dart';
 import 'package:statera/ui/widgets/page_scaffold.dart';
 
 class ExpensePage extends StatelessWidget {
@@ -61,7 +62,26 @@ class ExpensePage extends StatelessWidget {
           final expense = expenseState.expense;
           final expenseCanBeUpdated = expense.canBeUpdatedBy(authBloc.uid);
 
+          final allItemsMarked = expense.items.every(
+            (item) => item.isMarkedBy(authBloc.uid),
+          );
+
           return PageScaffold(
+            canPop: allItemsMarked,
+            onPop: (didPop) async {
+              if (didPop) return;
+              final confirmed = await showDialog(
+                context: context,
+                builder: (_) => OKCancelDialog(
+                  title: 'Are you sure you want to exit?',
+                  text:
+                      'Looks like you have some unmarked items in this expense. Make sure that all items are either accepted or rejected.',
+                ),
+              );
+              if (confirmed == true) {
+                Navigator.of(context).pop();
+              }
+            },
             fabText: 'New Item',
             onFabPressed: expenseCanBeUpdated && expense.hasItems
                 ? () => UpsertItemAction().safeHandle(context)

--- a/lib/ui/group/group_page.dart
+++ b/lib/ui/group/group_page.dart
@@ -24,6 +24,8 @@ import 'package:statera/ui/widgets/dialogs/new_expense_dialog/new_expense_dialog
 import 'package:statera/ui/widgets/page_scaffold.dart';
 import 'package:statera/ui/widgets/unmarked_expenses_badge.dart';
 
+const PAGE_ANIMATION_DURATION = Duration(milliseconds: 500);
+
 class GroupPage extends StatefulWidget {
   static const String name = 'Group';
   static final scaffoldKey = GlobalKey<ScaffoldState>();
@@ -100,6 +102,15 @@ class _GroupPageState extends State<GroupPage> {
       key: GroupPage.scaffoldKey,
       titleWidget: GroupTitle(),
       actions: [GroupQRButton()],
+      canPop: _selectedNavBarItemIndex == 0,
+      onPop: (didPop) async {
+        if (didPop) return;
+        await _pageController.animateToPage(
+          0,
+          duration: PAGE_ANIMATION_DURATION,
+          curve: Curves.ease,
+        );
+      },
       fabText: 'New Expense',
       onFabPressed: isWide || _selectedNavBarItemIndex != 1
           ? null
@@ -123,7 +134,7 @@ class _GroupPageState extends State<GroupPage> {
               onTap: (index) async {
                 await _pageController.animateToPage(
                   index,
-                  duration: Duration(milliseconds: 500),
+                  duration: PAGE_ANIMATION_DURATION,
                   curve: Curves.ease,
                 );
               },

--- a/lib/ui/group/group_page.dart
+++ b/lib/ui/group/group_page.dart
@@ -102,9 +102,9 @@ class _GroupPageState extends State<GroupPage> {
       key: GroupPage.scaffoldKey,
       titleWidget: GroupTitle(),
       actions: [GroupQRButton()],
-      canPop: _selectedNavBarItemIndex == 0,
+      canPop: isWide || _selectedNavBarItemIndex == 0,
       onPop: (didPop) async {
-        if (didPop) return;
+        if (didPop || isWide) return;
         await _pageController.animateToPage(
           0,
           duration: PAGE_ANIMATION_DURATION,

--- a/lib/ui/group/group_page.dart
+++ b/lib/ui/group/group_page.dart
@@ -24,7 +24,7 @@ import 'package:statera/ui/widgets/dialogs/new_expense_dialog/new_expense_dialog
 import 'package:statera/ui/widgets/page_scaffold.dart';
 import 'package:statera/ui/widgets/unmarked_expenses_badge.dart';
 
-const PAGE_ANIMATION_DURATION = Duration(milliseconds: 500);
+const kPakeAnimationDuration = Duration(milliseconds: 500);
 
 class GroupPage extends StatefulWidget {
   static const String name = 'Group';
@@ -107,7 +107,7 @@ class _GroupPageState extends State<GroupPage> {
         if (didPop || isWide) return;
         await _pageController.animateToPage(
           0,
-          duration: PAGE_ANIMATION_DURATION,
+          duration: kPakeAnimationDuration,
           curve: Curves.ease,
         );
       },
@@ -134,7 +134,7 @@ class _GroupPageState extends State<GroupPage> {
               onTap: (index) async {
                 await _pageController.animateToPage(
                   index,
-                  duration: PAGE_ANIMATION_DURATION,
+                  duration: kPakeAnimationDuration,
                   curve: Curves.ease,
                 );
               },

--- a/lib/ui/widgets/page_scaffold.dart
+++ b/lib/ui/widgets/page_scaffold.dart
@@ -10,6 +10,7 @@ class PageScaffold extends StatelessWidget {
   final List<Widget>? actions;
   final Widget? bottomNavBar;
   final String? fabText;
+  final bool canPop;
   final void Function()? onFabPressed;
   final void Function(bool didPop)? onPop;
   final Widget? fab;
@@ -22,6 +23,7 @@ class PageScaffold extends StatelessWidget {
     this.actions,
     this.bottomNavBar,
     this.fabText,
+    this.canPop = true,
     this.onFabPressed,
     this.onPop,
     this.fab,
@@ -36,6 +38,7 @@ class PageScaffold extends StatelessWidget {
         ((_, titleWidgetBuilder) => titleWidgetBuilder(this.title ?? ''));
 
     return PopScope(
+      canPop: this.canPop,
       onPopInvokedWithResult:
           onPop == null ? null : (didPop, _) => onPop!.call(didPop),
       child: Scaffold(


### PR DESCRIPTION
# Description

- Navigates to the debts tab first before navigating back from the group page in portrait mode
- Adds confirmation dialog before exiting an unmarked expense

# Issue

This PR closes #357 and closes #358

# Checklist

- [ ] This PR adds new tests
- [ ] This PR adds environment variables/files
- [ ] This PR updates documentation as required
