### PR TITLE
Fix support page back navigation

### DIFF
--- a/lib/ui/groups/group_list_page.dart
+++ b/lib/ui/groups/group_list_page.dart
@@ -58,7 +58,7 @@ class GroupListPage extends StatelessWidget {
             title: kAppName,
             actions: [
               IconButton(
-                onPressed: () => context.goNamed(SupportPage.name),
+                onPressed: () => context.pushNamed(SupportPage.name),
                 icon: Icon(Icons.info_outline_rounded),
               ),
               IconButton(


### PR DESCRIPTION
# Description

Pushes the Support page onto the navigation stack so that the back button is visible.

# Issue

This PR closes #359

# Checklist

- [ ] This PR adds new tests
- [ ] This PR adds environment variables/files
- [ ] This PR updates documentation as required
